### PR TITLE
Rename choria.use_srv_records -> choria.use_srv

### DIFF
--- a/docs/SCENARIO-FLAT.md
+++ b/docs/SCENARIO-FLAT.md
@@ -55,7 +55,7 @@ loglevel = warn
 main_collective = mcollective
 securityprovider = choria
 plugin.choria.security.serializer = json
-plugin.choria.use_srv_records = false
+plugin.choria.use_srv = false
 ```
 
 Run the scenario using `measure-collective.rb --config emulator-client.cfg` with additional options for amount of tests etc


### PR DESCRIPTION
Choria use `choria.use_srv` to check SRV records while MCollective used
`choria.use_srv_records` for this purpose.  We are updating the mcorpc
support gem to use a single setting `choria.use_srv` so update this
repository accordingly.